### PR TITLE
Torrent name caused PTN to crash.

### DIFF
--- a/PTN/__init__.py
+++ b/PTN/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from .parse import PTN
 
 __author__ = 'Divij Bindlish'

--- a/PTN/parse.py
+++ b/PTN/parse.py
@@ -4,7 +4,7 @@ import re
 from .patterns import patterns, types
 
 
-class PTN:
+class PTN(object):
     def _escapeRegex(self, string):
         return re.sub('[\-\[\]{}()*+?.,\\\^$|#\s]', '\\$&', string)
 
@@ -84,8 +84,9 @@ class PTN:
                 if re.match('[^ ]+ [^ ]+ .+', clean):
                     key = 'episodeName'
             if key == 'episode':
+                sub_pattern = self._escapeRegex(match[index['raw']])
                 self.torrent['map'] = re.sub(
-                    match[index['raw']], '{episode}', self.torrent['name']
+                    sub_pattern, '{episode}', self.torrent['name']
                 )
             self._part(key, match, match[index['raw']], clean)
 

--- a/PTN/parse.py
+++ b/PTN/parse.py
@@ -5,13 +5,13 @@ from .patterns import patterns, types
 
 
 class PTN(object):
-    def _escapeRegex(self, string):
+    def _escape_regex(self, string):
         return re.sub('[\-\[\]{}()*+?.,\\\^$|#\s]', '\\$&', string)
 
     def __init__(self):
         self.torrent = None
         self.excess_raw = None
-        self.groupRaw = None
+        self.group_raw = None
         self.start = None
         self.end = None
         self.title_raw = None
@@ -32,7 +32,7 @@ class PTN(object):
         if name != 'excess':
             # The instructions for adding excess
             if name == 'group':
-                self.groupRaw = raw
+                self.group_raw = raw
             if raw is not None:
                 self.excess_raw = self.excess_raw.replace(raw, '')
 
@@ -48,7 +48,7 @@ class PTN(object):
         self.parts = {}
         self.torrent = {'name': name}
         self.excess_raw = name
-        self.groupRaw = ''
+        self.group_raw = ''
         self.start = 0
         self.end = None
         self.title_raw = None
@@ -84,7 +84,7 @@ class PTN(object):
                 if re.match('[^ ]+ [^ ]+ .+', clean):
                     key = 'episodeName'
             if key == 'episode':
-                sub_pattern = self._escapeRegex(match[index['raw']])
+                sub_pattern = self._escape_regex(match[index['raw']])
                 self.torrent['map'] = re.sub(
                     sub_pattern, '{episode}', self.torrent['name']
                 )
@@ -112,17 +112,17 @@ class PTN(object):
 
         clean = [item for item in filter(bool, match)]
         if len(clean) != 0:
-            groupPattern = clean[-1] + self.groupRaw
-            if self.torrent['name'].find(groupPattern) == \
-                    len(self.torrent['name']) - len(groupPattern):
-                self._late('group', clean.pop() + self.groupRaw)
+            group_pattern = clean[-1] + self.group_raw
+            if self.torrent['name'].find(group_pattern) == \
+                    len(self.torrent['name']) - len(group_pattern):
+                self._late('group', clean.pop() + self.group_raw)
 
             if 'map' in self.torrent.keys() and len(clean) != 0:
-                episodeNamePattern = (
+                episode_name_pattern = (
                     '{episode}'
                     '' + re.sub('_+$', '', clean[0])
                 )
-                if self.torrent['map'].find(episodeNamePattern) != -1:
+                if self.torrent['map'].find(episode_name_pattern) != -1:
                     self._late('episodeName', clean.pop(0))
 
         if len(clean) != 0:

--- a/PTN/parse.py
+++ b/PTN/parse.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import re
-
 from .patterns import patterns, types
 
 
 class PTN:
-
     def _escapeRegex(self, string):
         return re.sub('[\-\[\]{}()*+?.,\\\^$|#\s]', '\\$&', string)
 
@@ -33,7 +33,6 @@ class PTN:
             # The instructions for adding excess
             if name == 'group':
                 self.groupRaw = raw
-
             if raw is not None:
                 self.excess_raw = self.excess_raw.replace(raw, '')
 
@@ -76,23 +75,18 @@ class PTN:
                 clean = True
             else:
                 clean = match[index['clean']]
-
                 if key in types.keys() and types[key] == 'integer':
                     clean = int(clean)
-
             if key == 'group':
                 if re.search(patterns[5][1], clean, re.I) \
                         or re.search(patterns[4][1], clean):
-                    # Codec and quality
-                    continue
-
+                    continue  # Codec and quality.
                 if re.match('[^ ]+ [^ ]+ .+', clean):
                     key = 'episodeName'
-
             if key == 'episode':
-                self.torrent['map'] = re.sub(match[index['raw']], '{episode}',
-                                             self.torrent['name'])
-
+                self.torrent['map'] = re.sub(
+                    match[index['raw']], '{episode}', self.torrent['name']
+                )
             self._part(key, match, match[index['raw']], clean)
 
         # Start process for title
@@ -101,10 +95,8 @@ class PTN:
             raw = raw[self.start:self.end].split('(')[0]
 
         clean = re.sub('^ -', '', raw)
-
         if clean.find(' ') == -1 and clean.find('.') != -1:
             clean = re.sub('\.', ' ', clean)
-
         clean = re.sub('_', ' ', clean)
         clean = re.sub('([\(_]|- )$', '', clean).strip()
 
@@ -118,7 +110,6 @@ class PTN:
             match = list(match[0])
 
         clean = [item for item in filter(bool, match)]
-
         if len(clean) != 0:
             groupPattern = clean[-1] + self.groupRaw
             if self.torrent['name'].find(groupPattern) == \
@@ -130,14 +121,11 @@ class PTN:
                     '{episode}'
                     '' + re.sub('_+$', '', clean[0])
                 )
-
                 if self.torrent['map'].find(episodeNamePattern) != -1:
                     self._late('episodeName', clean.pop(0))
 
         if len(clean) != 0:
             if len(clean) == 1:
                 clean = clean[0]
-
             self._part('excess', [], self.excess_raw, clean)
-
         return self.parts

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -1,14 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 patterns = [
     ('season', '([Ss]?([0-9]{1,2}))[Eex]'),
     ('episode', '([Eex]([0-9]{2})(?:[^0-9]|$))'),
     ('year', '([\[\(]?((?:19[0-9]|20[01])[0-9])[\]\)]?)'),
     ('resolution', '(([0-9]{3,4}p))[^M]'),
     ('quality', ('(?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV '
-                ')?WEB-?DL(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDR'
-                'IP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv')),
+                 ')?WEB-?DL(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDR'
+                 'IP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv')),
     ('codec', 'xvid|x264|h\.?264'),
     ('audio', ('MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)'
-              '?|AC3(?:\.5\.1)?')),
+               '?|AC3(?:\.5\.1)?')),
     ('group', '(- ?([^-]+(?:-={[^-]+-?$)?))$'),
     ('region', 'R[0-9]'),
     ('extended', 'EXTENDED'),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import json
 import os
 import unittest
@@ -6,24 +8,18 @@ import PTN
 
 
 class ParseTest(unittest.TestCase):
-
     def test_parser(self):
-        with open(os.path.join(
-                os.path.dirname(__file__),
-                'files/input.json'
-                )) as input_file:
+        json_input = os.path.join(os.path.dirname(__file__), 'files/input.json')
+        with open(json_input) as input_file:
             torrents = json.load(input_file)
 
-        with open(os.path.join(
-                os.path.dirname(__file__),
-                'files/output.json'
-                )) as output_file:
+        json_output = os.path.join(os.path.dirname(__file__), 'files/output.json')
+        with open(json_output) as output_file:
             expected_results = json.load(output_file)
 
         for torrent, expected_result in zip(torrents, expected_results):
             result = PTN.parse(torrent)
             self.assertEqual(result, expected_result)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When testing parse-torrent-name, I noticed that when I try to parse:

```
PTN.parse('30 Rock S05e08[Mux - XviD - Ita Mp3][TntVillage]')
```

It gives the following error:

```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    PTN.parse('30 Rock S05e08[Mux - XviD - Ita Mp3][TntVillage]')
  File "/Users/davidvuong/Dropbox/workspace/parse-torrent-name/PTN/__init__.py", line 14, in parse
    return ptn.parse(name)
  File "/Users/davidvuong/Dropbox/workspace/parse-torrent-name/PTN/parse.py", line 88, in parse
    match[index['raw']], '{episode}', self.torrent['name']
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py", line 155, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py", line 251, in _compile
    raise error, v # invalid expression
sre_constants.error: unexpected end of regular expression
```

I've fixed it by simply wrapping `match[index['raw']]` inside the `_escape_regex` method you had written. Other changes were just syntax related.