### PR TITLE
Match regex with word boundaries

### DIFF
--- a/PTN/parse.py
+++ b/PTN/parse.py
@@ -55,10 +55,15 @@ class PTN(object):
         self.title_raw = None
 
         for key, pattern in patterns:
+            if key not in ('season', 'episode', 'website'):
+                pattern = r'\b%s\b' % pattern
+
+            clean_name = re.sub('_', ' ', self.torrent['name'])
+
             if key == 'codec':
-                match = re.findall(pattern, self.torrent['name'], re.I)
+                match = re.findall(pattern, clean_name, re.I)
             else:
-                match = re.findall(pattern, self.torrent['name'])
+                match = re.findall(pattern, clean_name)
             if len(match) == 0:
                 continue
 
@@ -100,7 +105,7 @@ class PTN(object):
         if clean.find(' ') == -1 and clean.find('.') != -1:
             clean = re.sub('\.', ' ', clean)
         clean = re.sub('_', ' ', clean)
-        clean = re.sub('([\(_]|- )$', '', clean).strip()
+        clean = re.sub('([\[\(_]|- )$', '', clean).strip()
 
         self._part('title', [], raw, clean)
 

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -5,10 +5,10 @@ patterns = [
     ('season', '([Ss]?([0-9]{1,2}))[Eex]'),
     ('episode', '([Eex]([0-9]{2})(?:[^0-9]|$))'),
     ('year', '([\[\(]?((?:19[0-9]|20[01])[0-9])[\]\)]?)'),
-    ('resolution', '(([0-9]{3,4}p))[^M]'),
-    ('quality', ('(?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV '
+    ('resolution', '([0-9]{3,4}p)'),
+    ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV '
                  ')?WEB-?DL(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDR'
-                 'IP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv')),
+                 'IP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv)')),
     ('codec', 'xvid|x264|h\.?264'),
     ('audio', ('MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)'
                '?|AC3(?:\.5\.1)?')),
@@ -18,7 +18,7 @@ patterns = [
     ('hardcoded', 'HC'),
     ('proper', 'PROPER'),
     ('repack', 'REPACK'),
-    ('container', 'MKV|AVI'),
+    ('container', '(MKV|AVI)'),
     ('widescreen', 'WS'),
     ('website', '^(\[ ?([^\]]+?) ?\])'),
     ('language', 'rus\.eng')

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -286,7 +286,7 @@
   {
     "year": 2014,
     "resolution": "1080p",
-    "quality": "TS",
+    "quality": "BRRip",
     "codec": "x264",
     "audio": "DTS",
     "title": "Into The Storm"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -19,8 +19,10 @@ class ParseTest(unittest.TestCase):
             expected_results = json.load(output_file)
 
         for torrent, expected_result in zip(torrents, expected_results):
+            print("Test: " + torrent)
             result = PTN.parse(torrent)
             for key in expected_result:
+                self.assertIn(key, result)
                 self.assertEqual(result[key], expected_result[key])
 
 if __name__ == '__main__':


### PR DESCRIPTION
This will make sure we won't treat part of word as a match.
E.g. without word boundaries DTS for audio matched also TS for quiality.

Fix test expected from TS to BRRip where needed.
Add some output to the unittest so it will be easy to read on error.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>