### PR TITLE
Match with ignore case

### DIFF
--- a/PTN/parse.py
+++ b/PTN/parse.py
@@ -59,11 +59,7 @@ class PTN(object):
                 pattern = r'\b%s\b' % pattern
 
             clean_name = re.sub('_', ' ', self.torrent['name'])
-
-            if key == 'codec':
-                match = re.findall(pattern, clean_name, re.I)
-            else:
-                match = re.findall(pattern, clean_name)
+            match = re.findall(pattern, clean_name, re.I)
             if len(match) == 0:
                 continue
 

--- a/PTN/parse.py
+++ b/PTN/parse.py
@@ -106,13 +106,14 @@ class PTN(object):
         self._part('title', [], raw, clean)
 
         # Start process for end
-        clean = re.sub('(^[-\. ]+)|([-\. ]+$)', '', self.excess_raw)
+        clean = re.sub('(^[-\. ()]+)|([-\. ]+$)', '', self.excess_raw)
         clean = re.sub('[\(\)\/]', ' ', clean)
         match = re.split('\.\.+| +', clean)
         if len(match) > 0 and isinstance(match[0], tuple):
             match = list(match[0])
 
         clean = [item for item in filter(bool, match)]
+        clean = [item for item in filter(lambda a: a != '-', clean)]
         if len(clean) != 0:
             group_pattern = clean[-1] + self.group_raw
             if self.torrent['name'].find(group_pattern) == \

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -6,7 +6,7 @@ patterns = [
     ('episode', '([ex]([0-9]{2})(?:[^0-9]|$))'),
     ('year', '([\[\(]?((?:19[0-9]|20[01])[0-9])[\]\)]?)'),
     ('resolution', '([0-9]{3,4}p)'),
-    ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|BRRip|TS|(?:PPV '
+    ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[DR]Rip|TS|(?:PPV '
                  ')?WEB-?DL(?: DVDRip)?|HDRip|DVDRip|DVDR'
                  'IP|CamRip|W[EB]BRip|BluRay|DvDScr|hdtv)')),
     ('codec', 'xvid|x264|h\.?264'),

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -14,7 +14,7 @@ patterns = [
                '?|AC3(?:\.5\.1)?)')),
     ('group', '(- ?([^-]+(?:-={[^-]+-?$)?))$'),
     ('region', 'R[0-9]'),
-    ('extended', 'EXTENDED'),
+    ('extended', '(EXTENDED(:?.CUT)?)'),
     ('hardcoded', 'HC'),
     ('proper', 'PROPER'),
     ('repack', 'REPACK'),

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -9,9 +9,9 @@ patterns = [
     ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[DR]Rip|TS|(?:PPV '
                  ')?WEB-?DL(?: DVDRip)?|HDRip|DVDRip|DVDR'
                  'IP|CamRip|W[EB]BRip|BluRay|DvDScr|hdtv)')),
-    ('codec', 'xvid|x264|h\.?264'),
-    ('audio', ('MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)'
-               '?|AC3(?:\.5\.1)?')),
+    ('codec', '(xvid|x264|h\.?264)'),
+    ('audio', ('(MP3|DD5\.?1|Dual[\- ]Audio|LiNE|H?DTS|AAC(?:\.?2\.0)'
+               '?|AC3(?:\.5\.1)?)')),
     ('group', '(- ?([^-]+(?:-={[^-]+-?$)?))$'),
     ('region', 'R[0-9]'),
     ('extended', 'EXTENDED'),

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 patterns = [
-    ('season', '([Ss]?([0-9]{1,2}))[Eex]'),
-    ('episode', '([Eex]([0-9]{2})(?:[^0-9]|$))'),
+    ('season', '(s?([0-9]{1,2}))[ex]'),
+    ('episode', '([ex]([0-9]{2})(?:[^0-9]|$))'),
     ('year', '([\[\(]?((?:19[0-9]|20[01])[0-9])[\]\)]?)'),
     ('resolution', '([0-9]{3,4}p)'),
-    ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[rR]Rip|TS|(?:PPV '
-                 ')?WEB-?DL(?: DVDRip)?|H[dD]Rip|DVDRip|DVDRiP|DVDR'
-                 'IP|CamRip|W[EB]B[rR]ip|[Bb]lu[Rr]ay|DvDScr|hdtv)')),
+    ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|BRRip|TS|(?:PPV '
+                 ')?WEB-?DL(?: DVDRip)?|HDRip|DVDRip|DVDR'
+                 'IP|CamRip|W[EB]BRip|BluRay|DvDScr|hdtv)')),
     ('codec', 'xvid|x264|h\.?264'),
     ('audio', ('MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|AAC(?:\.?2\.0)'
                '?|AC3(?:\.5\.1)?')),

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -65,5 +65,6 @@
   "Community.s02e20.rus.eng.720p.Kybik.v.Kybe",
   "The.Jungle.Book.3D.2016.1080p.BRRip.SBS.x264.AAC-ETRG",
   "Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g",
-  "Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN"
+  "Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN",
+  "Red.Sonja.Queen.Of.Plagues.2016.BDRip.x264-W4F[PRiME]"
 ]

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -66,5 +66,6 @@
   "The.Jungle.Book.3D.2016.1080p.BRRip.SBS.x264.AAC-ETRG",
   "Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g",
   "Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN",
-  "Red.Sonja.Queen.Of.Plagues.2016.BDRip.x264-W4F[PRiME]"
+  "Red.Sonja.Queen.Of.Plagues.2016.BDRip.x264-W4F[PRiME]",
+  "The Purge: Election Year (2016) HC - 720p HDRiP - 900MB - ShAaNi"
 ]

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -5,7 +5,7 @@
   "The Big Bang Theory S08E06 HDTV XviD-LOL [eztv]",
   "22 Jump Street (2014) 720p BrRip x264 - YIFY",
   "Hercules.2014.EXTENDED.1080p.WEB-DL.DD5.1.H264-RARBG",
-  "Hercules.2014.EXTENDED.HDRip.XViD-juggs[ETRG]",
+  "Hercules.2014.Extended.Cut.HDRip.XViD-juggs[ETRG]",
   "Hercules (2014) WEBDL DVDRip XviD-MAX",
   "WWE Hell in a Cell 2014 PPV WEB-DL x264-WD -={SPARROW}=-",
   "UFC.179.PPV.HDTV.x264-Ebi[rartv]",

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -67,5 +67,6 @@
   "Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g",
   "Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN",
   "Red.Sonja.Queen.Of.Plagues.2016.BDRip.x264-W4F[PRiME]",
-  "The Purge: Election Year (2016) HC - 720p HDRiP - 900MB - ShAaNi"
+  "The Purge: Election Year (2016) HC - 720p HDRiP - 900MB - ShAaNi",
+  "War Dogs (2016) HDTS 600MB - NBY"
 ]

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -64,5 +64,6 @@
   "[ www.Speed.cd ] -Sons.of.Anarchy.S07E07.720p.HDTV.X264-DIMENSION",
   "Community.s02e20.rus.eng.720p.Kybik.v.Kybe",
   "The.Jungle.Book.3D.2016.1080p.BRRip.SBS.x264.AAC-ETRG",
-  "Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g"
+  "Ant-Man.2015.3D.1080p.BRRip.Half-SBS.x264.AAC-m2g",
+  "Ice.Age.Collision.Course.2016.READNFO.720p.HDRIP.X264.AC3.TiTAN"
 ]

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -469,5 +469,9 @@
   {
     "title": "Ice Age Collision Course",
     "quality": "HDRIP"
+  },
+  {
+    "title": "Red Sonja Queen Of Plagues",
+    "quality": "BDRip"
   }
 ]

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -465,5 +465,9 @@
   {
     "title": "Ant-Man",
     "sbs": "Half-SBS"
+  },
+  {
+    "title": "Ice Age Collision Course",
+    "quality": "HDRIP"
   }
 ]

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -49,6 +49,7 @@
     "quality": "HDRip",
     "codec": "XViD",
     "extended": true,
+    "excess": "",
     "title": "Hercules"
   },
   {

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -12,6 +12,7 @@
     "resolution": "1080p",
     "quality": "BrRip",
     "codec": "H264",
+    "excess": "",
     "title": "Hercules"
   },
   {
@@ -473,5 +474,9 @@
   {
     "title": "Red Sonja Queen Of Plagues",
     "quality": "BDRip"
+  },
+  {
+    "title": "The Purge: Election Year",
+    "excess": "900MB"
   }
 ]

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -478,5 +478,9 @@
   {
     "title": "The Purge: Election Year",
     "excess": "900MB"
+  },
+  {
+    "title": "War Dogs",
+    "audio": "HDTS"
   }
 ]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -24,8 +24,11 @@ class ParseTest(unittest.TestCase):
             print("Test: " + torrent)
             result = PTN.parse(torrent)
             for key in expected_result:
-                self.assertIn(key, result)
-                self.assertEqual(result[key], expected_result[key])
+                if not expected_result[key]:
+                    self.assertNotIn(key, result)
+                else:
+                    self.assertIn(key, result)
+                    self.assertEqual(result[key], expected_result[key])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We use word boundaries to make sure we don't just match a substring
so do the matching with ignore case as names could always have different
case that can be missed and it shouldn't matter.
e.g. HDRiP was missed while HDRip was ok.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>