### PR TITLE
Additional Quality and Codec Possibilities

### DIFF
--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -8,8 +8,8 @@ patterns = [
     ('resolution', '([0-9]{3,4}p)'),
     ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[DR]Rip|(?:HD-?)?TS|'
                  '(?:PPV )?WEB-?DL(?: DVDRip)?|HDRip|DVDRip|DVDRIP|'
-                 'CamRip|W[EB]BRip|BluRay|DvDScr|hdtv|telesync)')),
-    ('codec', '(xvid|[hx]\.?26[45])'),
+                 'CamRip|W[EB]BRip|BluRay|DvDScr|hdtv|telesync|720p|1080p)')),
+    ('codec', '(xvid|[hx][\. ]?26[45])|HEVC'),
     ('audio', ('(MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|'
                'AAC[.-]LC|AAC(?:\.?2\.0)?|'
                'AC3(?:\.5\.1)?)')),

--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -8,8 +8,8 @@ patterns = [
     ('resolution', '([0-9]{3,4}p)'),
     ('quality', ('((?:PPV\.)?[HP]DTV|(?:HD)?CAM|B[DR]Rip|(?:HD-?)?TS|'
                  '(?:PPV )?WEB-?DL(?: DVDRip)?|HDRip|DVDRip|DVDRIP|'
-                 'CamRip|W[EB]BRip|BluRay|DvDScr|hdtv|telesync|720p|1080p)')),
-    ('codec', '(xvid|[hx][\. ]?26[45])|HEVC'),
+                 'CamRip|W[EB]BRip|BluRay|DvDScr|hdtv|telesync)')),
+    ('codec', '(xvid|[hx]\.?26[45])|HEVC'),
     ('audio', ('(MP3|DD5\.?1|Dual[\- ]Audio|LiNE|DTS|'
                'AAC[.-]LC|AAC(?:\.?2\.0)?|'
                'AC3(?:\.5\.1)?)')),


### PR DESCRIPTION
Added 720p and 1080p to quality.
Added space as an option to period for H.264, X.265 to be represented as H 264, X 265.  I personally don't like it, but it's now common in torrent names.
Added HEVC to codecs, as it's a technical alternate name for h.265, and popular in torrent names.