### PR TITLE
Fix setup.py README read to work on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import os
+import codecs
 from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
+readme_path = os.path.join(os.path.dirname(__file__), 'README.md')
+
+with codecs.open(readme_path, mode='r', encoding='utf-8') as f:
     description = f.read()
 
 setup(


### PR DESCRIPTION
Fixes the ability to `pip install` on Windows. 

Would fail from an ambiguous file type error when trying to read the README file in `setup.py`. Using `codecs` module allows specifying an encoding parameter, which is only available in `open(..)` in Python3+.