### PR TITLE
Add ISO 8601 Date Parsing

### DIFF
--- a/PTN/patterns.py
+++ b/PTN/patterns.py
@@ -26,13 +26,17 @@ patterns = [
     ('sbs', '(?:Half-)?SBS'),
     ('unrated', 'UNRATED'),
     ('size', '(\d+(?:\.\d+)?(?:GB|MB))'),
-    ('3d', '3D')
+    ('3d', '3D'),
+    ('month', '[\[\(]?(?:19[0-9]|20[01])[0-9][\]\)]?[\.|\s]?(\d{2})[\.|\s]?\d{2}'),
+    ('day', '[\[\(]?(?:19[0-9]|20[01])[0-9][\]\)]?[\.|\s]?\d{2}[\.|\s]?(\d{2})')
 ]
 
 types = {
     'season': 'integer',
     'episode': 'integer',
     'year': 'integer',
+    'month': 'integer',
+    'day': 'integer',
     'extended': 'boolean',
     'hardcoded': 'boolean',
     'proper': 'boolean',

--- a/tests/files/input.json
+++ b/tests/files/input.json
@@ -74,5 +74,8 @@
   "Return.To.Snowy.River.1988.iNTERNAL.DVDRip.x264-W4F[PRiME]",
   "Akira (2016) - UpScaled - 720p - DesiSCR-Rip - Hindi - x264 - AC3 - 5.1 - Mafiaking - M2Tv",
   "Ben Hur 2016 TELESYNC x264 AC3 MAXPRO",
-  "The.Secret.Life.of.Pets.2016.HDRiP.AAC-LC.x264-LEGi0N"
+  "The.Secret.Life.of.Pets.2016.HDRiP.AAC-LC.x264-LEGi0N",
+  "Jimmy.Fallon.2018.04.06.Tiffany.Haddish.720p.HDTV.x264-SORNY",
+  "The.Footy.Show.AFL.2018.03.21.HDTV.x264-CBFM",
+  "NRL.2018.04.06.Dragons.vs.Rabbitohs.1080p.HDTV.x264-PLUTONiUM"
 ]

--- a/tests/files/output.json
+++ b/tests/files/output.json
@@ -511,5 +511,35 @@
   {
     "title": "The Secret Life of Pets",
     "audio": "AAC-LC"
+  },
+  {
+    "group": "SORNY",
+    "title": "Jimmy Fallon",
+    "resolution": "720p",
+    "codec": "x264",
+    "year": 2018,
+    "month": 4,
+    "day": 6,
+    "quality": "HDTV"
+  },
+  {
+    "group": "CBFM",
+    "title": "The Footy Show AFL",
+    "codec": "x264",
+    "year": 2018,
+    "month": 3,
+    "day": 21,
+    "quality": "HDTV"
+  },
+  {
+    "group": "PLUTONiUM",
+    "title": "NRL",
+    "resolution": "1080p",
+    "codec": "x264",
+    "year": 2018,
+    "month": 4,
+    "day": 6,
+    "quality": "HDTV"
   }
+
 ]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -4,6 +4,10 @@
 import json
 import os
 import unittest
+import sys
+
+# Force using PTN relative to this test file
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
 
 import PTN
 


### PR DESCRIPTION
Adds capability to detect any ISO 8601 dates in the title after the year. #14 as a result.
Added new tests which pass.
Modified the test script to test PTN relative to the repo (to stop a repeat of #21).